### PR TITLE
fix sizes cqi to vw

### DIFF
--- a/games/css/chains.css
+++ b/games/css/chains.css
@@ -29,6 +29,7 @@
   .button-group {
     /* width: 70em; */
     margin-block: 2em 4em;
+    font-size: 1.2vw;
     font-size: 1.2cqi;
   }
 
@@ -89,6 +90,7 @@ body:not(:has(:invalid)) #scrim-good {
 /** GAME *******/
 
 .chain {
+  font-size: 1.2vw;
   font-size: 1.2cqi;
   height: 30em;
   width: 70em;

--- a/games/css/chains.css
+++ b/games/css/chains.css
@@ -91,7 +91,7 @@ body:not(:has(:invalid)) #scrim-good {
 
 .chain {
   font-size: 1.2vw;
-  font-size: min(1.2vw, 14.4px);
+  font-size: min(1.2vw, 14px);
   font-size: 1.2cqi;
   height: 30em;
   width: 70em;

--- a/games/css/chains.css
+++ b/games/css/chains.css
@@ -91,6 +91,7 @@ body:not(:has(:invalid)) #scrim-good {
 
 .chain {
   font-size: 1.2vw;
+  font-size: min(1.2vw, 14.4px);
   font-size: 1.2cqi;
   height: 30em;
   width: 70em;

--- a/games/css/color-stairs.css
+++ b/games/css/color-stairs.css
@@ -84,6 +84,7 @@ p {
 
 article#game-main {
   --color: #cef;
+  font-size: 2.5vw;
   font-size: 2.5cqi;
   margin-inline: 0.2em;
   margin-inline-end: 2em;

--- a/games/css/color-stairs.css
+++ b/games/css/color-stairs.css
@@ -85,6 +85,7 @@ p {
 article#game-main {
   --color: #cef;
   font-size: 2.5vw;
+  font-size: min(2.5vw, 30px);
   font-size: 2.5cqi;
   margin-inline: 0.2em;
   margin-inline-end: 2em;

--- a/games/css/css-colors.css
+++ b/games/css/css-colors.css
@@ -85,6 +85,7 @@
   article {
     --color: #cef;
     font-size: 2.5vw;
+    font-size: min(2.5vw, 30px);
     font-size: 2.5cqi;
     display: inline-flex;
     flex-direction: column;

--- a/games/css/css-colors.css
+++ b/games/css/css-colors.css
@@ -84,6 +84,7 @@
 
   article {
     --color: #cef;
+    font-size: 2.5vw;
     font-size: 2.5cqi;
     display: inline-flex;
     flex-direction: column;

--- a/games/css/sequences.css
+++ b/games/css/sequences.css
@@ -138,7 +138,7 @@ section:has(.animate:active) .code {
     margin: 0;
     padding: 0;
     background: var(--bg);
-    box-shadow: inset 0 0 0 1vw var(--bg);
+    box-shadow: inset 0 0 0 2px var(--bg);
     box-shadow: inset 0 0 0 1cqi var(--bg);
     cursor: pointer;
 

--- a/games/css/sequences.css
+++ b/games/css/sequences.css
@@ -129,8 +129,8 @@ section:has(.animate:active) .code {
     box-sizing: border-box;
     position: absolute;
     appearance: none;
-    width: 15vw !important;
-    height: 15vw !important;
+    width: 15% !important;
+    height: 15% !important;
     width: 15cqi !important;
     height: 15cqi !important;
     border: 1px solid !important;

--- a/games/css/sequences.css
+++ b/games/css/sequences.css
@@ -129,6 +129,8 @@ section:has(.animate:active) .code {
     box-sizing: border-box;
     position: absolute;
     appearance: none;
+    width: 15vw !important;
+    height: 15vw !important;
     width: 15cqi !important;
     height: 15cqi !important;
     border: 1px solid !important;
@@ -136,6 +138,7 @@ section:has(.animate:active) .code {
     margin: 0;
     padding: 0;
     background: var(--bg);
+    box-shadow: inset 0 0 0 1vw var(--bg);
     box-shadow: inset 0 0 0 1cqi var(--bg);
     cursor: pointer;
 

--- a/games/js/fourconnect.js
+++ b/games/js/fourconnect.js
@@ -214,7 +214,7 @@ class FourConnect extends HTMLElement {
     shadow.innerHTML = `
 <style>
 article {
-  --size: 100vw;
+  --size: 100%;
   --gap: 1em;
   --font: 1.5vw;
   container-type: inline-size;
@@ -228,12 +228,17 @@ article {
 
   @media (width > 600px) {
     --size: 500px;
+    --font: 7.5px;
     width: var(--size);
+
+    @supports (width: 75cqi) {
+      --font: 1.5cqi;
+    }
   }
 
   @media (width > 1000px) {
     --size: 750px;
-    --font: 1.25vw;
+    --font: 9px;
 
     @supports (width: 75cqi) {
       --font: 1.25cqi;
@@ -255,6 +260,7 @@ h2 {
   gap: var(--gap);
   grid-template-columns: repeat(4, 1fr);
   grid-template-rows: repeat(4, 1fr);
+  aspect-ratio: 1;
 
   @media (width > 1000px) {
     height: calc(var(--size) * 0.6);

--- a/games/js/fourconnect.js
+++ b/games/js/fourconnect.js
@@ -214,12 +214,17 @@ class FourConnect extends HTMLElement {
     shadow.innerHTML = `
 <style>
 article {
-  --size: 100cqi;
+  --size: 100vw;
   --gap: 1em;
-  --font: 1.5cqi;
+  --font: 1.5vw;
   container-type: inline-size;
   width: 100%;
   margin: auto;
+
+  @supports (width: 100cqi) {
+    --size: 100cqi;
+    --font: 1.5cqi;
+  }
 
   @media (width > 600px) {
     --size: 500px;
@@ -228,7 +233,11 @@ article {
 
   @media (width > 1000px) {
     --size: 750px;
-    --font: 1.25cqi;
+    --font: 1.25vw;
+
+    @supports (width: 75cqi) {
+      --font: 1.25cqi;
+    }
   }
 }
 


### PR DESCRIPTION
fallback cqi with vw in games.

This pull request focuses on improving the responsive sizing of fonts and elements across several CSS files and a JavaScript component for various games. The main change is the addition of fallback `vw` (viewport width) units alongside the newer `cqi` (container query inline) units, ensuring better cross-browser compatibility and consistent appearance regardless of support for container queries.

**Responsive sizing improvements:**

* Added fallback `vw` font sizes alongside `cqi` units in `.button-group` and `.chain` classes in `chains.css`, ensuring font sizes scale with the viewport if container queries are not supported. [[1]](diffhunk://#diff-cdd31ff861aed8be3f43040ba655a4f357fad0977edde833bcdb95280c2dd6c3R32) [[2]](diffhunk://#diff-cdd31ff861aed8be3f43040ba655a4f357fad0977edde833bcdb95280c2dd6c3R93)
* Added fallback `2.5vw` font size in `article#game-main` in `color-stairs.css` and in `article` in `css-colors.css` for improved consistency. [[1]](diffhunk://#diff-0f1e0969295e781a5a1cdd24d04608c84af1ffb89baaf35e7059ef8a172ba9c0R87) [[2]](diffhunk://#diff-54a1d28e47470a88601f9916406c240f8a47805dfca4dfec1b94534ec8805c9fR87)
* Updated `.code` elements in `sequences.css` to include `vw`-based width, height, and box-shadow as fallbacks to their `cqi` equivalents, enhancing cross-browser layout consistency.

**JavaScript component enhancements:**

* Modified the `FourConnect` web component's internal CSS to use `vw` units for `--size` and `--font` by default, with conditional overrides to `cqi` if supported, and further adjustments for larger screens. This ensures the component scales responsively and gracefully degrades if container queries are unsupported.