### PR TITLE
Bug/fix safari issues with marker

### DIFF
--- a/games/11/index.html
+++ b/games/11/index.html
@@ -1788,7 +1788,7 @@
 </article>
 
 
-<div class="hints" tabindex="-1">
+<div id="hints">
   <section>
     <h2>Across</h2>
     <ol class="across">

--- a/games/12/index.html
+++ b/games/12/index.html
@@ -2492,7 +2492,7 @@ Puzzle schema and solution line by line (it's a 25x30 grid):
 </article>
 
 
-      <div class="hints" tabindex="-1">
+      <div id="hints">
         <section>
           <h2>Across</h2>
           <ol class="across">

--- a/games/14/index.html
+++ b/games/14/index.html
@@ -2412,7 +2412,7 @@
   <div class="hoverhint" role="alert" id="hoverhint"></div>
 </article>
 
-      <div class="hints" tabindex="-1">
+      <div id="hints">
         <section>
           <h2>Across</h2>
           <ol class="across">

--- a/games/19/index.html
+++ b/games/19/index.html
@@ -564,7 +564,7 @@
   <span></span>
   <div class="hoverhint" role="alert" id="hoverhint"></div>
   </article>
-      <div class="hints" tabindex="-1">
+      <div id="hints">
         <section>
           <h2>Across</h2>
           <ol class="across">

--- a/games/26/index.html
+++ b/games/26/index.html
@@ -496,7 +496,7 @@
         <div class="hoverhint" role="alert" id="hoverhint"></div>
       </article>
 
-      <div class="hints" tabindex="-1">
+      <div id="hints">
         <section>
           <h2>Across</h2>
           <ol class="across">

--- a/games/28/index.html
+++ b/games/28/index.html
@@ -378,7 +378,7 @@
         <div class="hoverhint" role="alert" id="hoverhint"></div>
       </article>
 
-      <div class="hints" tabindex="-1">
+      <div id="hints">
         <section>
           <h2>Across</h2>
           <ol class="across">

--- a/games/38/index.html
+++ b/games/38/index.html
@@ -502,7 +502,7 @@
         <div class="hoverhint" role="alert" id="hoverhint"></div>
       </article>
 
-      <div class="hints" tabindex="-1">
+      <div id="hints">
         <section>
           <h2>Across</h2>
           <ol class="across">

--- a/games/51/index.html
+++ b/games/51/index.html
@@ -647,7 +647,7 @@
         <div class="hoverhint" role="alert" id="hoverhint"></div>
       </article>
 
-      <div class="hints" tabindex="-1">
+      <div id="hints">
         <section>
           <h2>Across</h2>     
           <ol class="across">

--- a/games/css/crosswords2.css
+++ b/games/css/crosswords2.css
@@ -492,27 +492,31 @@ article {
     }
 
     @media print {
-      column-count: 2;
+      columns: 2;
       column-gap: 3em;
       -webkit-print-color-adjust: exact;
       print-color-adjust: exact;
       break-after: page;
+      overflow: visible;
+      margin: 0;
+      padding: 0;
     }
 
     li {
-      list-style: attr(data-n);
-      padding-inline-start: 0.35em;
+      list-style: "";
+      padding-inline-start: 3ch;
+      position: relative;
+      overflow: visible;
 
-      &::marker {
-        font-weight: bolder;
-        content: attr(data-n) "."
+      &::before {
+        content: attr(data-n) ".";
+        font-weight: 700;
+        margin-inline-end: 0.35em;
+        position: absolute;
+        translate: -2em 0;
+        width: 3ch;
+        text-align: right;
       }
-
-      /*       &::before {
-      content: attr(data-o) ".";
-      font-weight: 700;
-      margin-inline-end: 0.35em;
-    } */
     }
   }
 }

--- a/games/css/crosswords2.css
+++ b/games/css/crosswords2.css
@@ -471,16 +471,12 @@ article {
   }
 }
 
-.hints {
+#hints {
   display: grid;
   font-size: 0.8em;
   font-size: 0.9em;
   margin-block-start: 2em;
   gap: 3em;
-
-  /* @media (width > 600px) {
-    grid-template-columns: 1fr 1fr;
-  } */
 
   ol {
     margin: 0;


### PR DESCRIPTION
Changes in the crosswords styling and structure:

- Replaced `class="hints"` with `id="hints"`
- Updated styles selectors for consistency with that change
- Removed `tabindex="-1"` from the hints to avoid focus outline
- Replaced the use of `::marker` with `::before` because Safari will do Safari things (like saying "I support `::marker`" when it really doesn't)
- Updated margins/paddings in hints section because Safari will do Safari things (like saying "Oh! you want columns? let me clip their overflow because f you, that's why!")